### PR TITLE
mejora a filtro familias

### DIFF
--- a/lobo_organizado/cuotas/templates/cuotas/g_pagos_listado.html
+++ b/lobo_organizado/cuotas/templates/cuotas/g_pagos_listado.html
@@ -1,7 +1,7 @@
 {% extends "base_site.html" %}
 
 {% block content %}
-<h1>Listado de cuotas vencidas</h1>
+<h1>Listado de cobranza</h1>
 
 {% block error_message %}
 {% if error_message %}<div class="alert alert-danger" role="alert">{{ error_message|unquote_raw }}</div>{% endif %}


### PR DESCRIPTION
Famila CRM ID
Socio nombres
socio apellidos

mantiene busqueda de familia por familia drm id (nombre de familia)

Hay que portar o reutilizar el filtro para gestion de pagos de cuotas

close